### PR TITLE
Add Glance page redirect

### DIFF
--- a/paraview-glance/README.md
+++ b/paraview-glance/README.md
@@ -1,0 +1,1 @@
+The "paraview-glance" repo has been renamed to "Glance", necessitating these page redirects.

--- a/paraview-glance/app/index.html
+++ b/paraview-glance/app/index.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <noscript>
+      <meta http-equiv="refresh" content="0; URL=https://kitware.github.io/Glance/app/">
+      <link rel="canonical" href="https://kitware.github.io/Glance/app/">
+    </noscript>
+    <script type="text/javascript">
+      var dest = 'https://kitware.github.io/Glance/app/';
+      var search = window.location.search || '';
+      var hash = window.location.hash || '';
+      window.location.href = dest + search + hash;
+    </script>
+  </head>
+</html>

--- a/paraview-glance/index.html
+++ b/paraview-glance/index.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <noscript>
+      <meta http-equiv="refresh" content="0; URL=https://kitware.github.io/Glance/">
+      <link rel="canonical" href="https://kitware.github.io/Glance/">
+    </noscript>
+    <script type="text/javascript">
+      window.location.href = 'https://kitware.github.io/Glance/';
+    </script>
+  </head>
+</html>

--- a/paraview-glance/nightly/index.html
+++ b/paraview-glance/nightly/index.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <noscript>
+      <meta http-equiv="refresh" content="0; URL=https://kitware.github.io/Glance/nightly/">
+      <link rel="canonical" href="https://kitware.github.io/Glance/nightly/">
+    </noscript>
+    <script type="text/javascript">
+      var dest = 'https://kitware.github.io/Glance/nightly/';
+      var search = window.location.search || '';
+      var hash = window.location.hash || '';
+      window.location.href = dest + search + hash;
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
The repo "paraview-glance" has been renamed to "Glance". In the interest of preserving the old application links, I would like to add these redirects, since the paraview-glance repo no longer exists.